### PR TITLE
Add finance pages and reusable components

### DIFF
--- a/App.razor
+++ b/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="@typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/Components/CategoryDropdown.razor
+++ b/Components/CategoryDropdown.razor
@@ -1,0 +1,17 @@
+<RadzenDropDown Data="Categories" TextProperty="Name" ValueProperty="Id" @bind-Value="selected" Change="OnChange" Style="width:100%" />
+
+@code {
+    [Parameter]
+    public IReadOnlyList<Category> Categories { get; set; } = new List<Category>();
+
+    [Parameter]
+    public EventCallback<int> OnCategoryChanged { get; set; }
+
+    private Task OnChange(object value)
+    {
+        int id = value is int v ? v : 0;
+        return OnCategoryChanged.InvokeAsync(id);
+    }
+
+    private int selected;
+}

--- a/Components/ConfirmDialog.razor
+++ b/Components/ConfirmDialog.razor
@@ -1,0 +1,21 @@
+<RadzenDialog Visible="@Visible" Style="width:400px" ShowClose="false">
+    <ChildContent>
+        <p>@Message</p>
+        <RadzenButton Text="OK" ButtonStyle="ButtonStyle.Primary" Click="() => OnConfirm.InvokeAsync()" />
+        <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Secondary" Click="() => OnCancel.InvokeAsync()" Style="margin-left:10px" />
+    </ChildContent>
+</RadzenDialog>
+
+@code {
+    [Parameter]
+    public string Message { get; set; } = "Are you sure?";
+
+    [Parameter]
+    public bool Visible { get; set; }
+
+    [Parameter]
+    public EventCallback OnConfirm { get; set; }
+
+    [Parameter]
+    public EventCallback OnCancel { get; set; }
+}

--- a/Components/DateRangePicker.razor
+++ b/Components/DateRangePicker.razor
@@ -1,0 +1,10 @@
+<RadzenDatePicker @bind-Value="Start" Style="width:150px" />
+<RadzenDatePicker @bind-Value="End" Style="width:150px;margin-left:10px" />
+
+@code {
+    [Parameter]
+    public DateTime Start { get; set; }
+
+    [Parameter]
+    public DateTime End { get; set; }
+}

--- a/Components/ExpenseChart.razor
+++ b/Components/ExpenseChart.razor
@@ -1,0 +1,14 @@
+<RadzenChart>
+    <RadzenPieSeries Data="Data" CategoryProperty="Category" ValueProperty="Value" />
+</RadzenChart>
+
+@code {
+    [Parameter]
+    public IEnumerable<ChartData> Data { get; set; } = Enumerable.Empty<ChartData>();
+
+    public class ChartData
+    {
+        public string Category { get; set; } = string.Empty;
+        public decimal Value { get; set; }
+    }
+}

--- a/Components/MonthlyReport.razor
+++ b/Components/MonthlyReport.razor
@@ -1,0 +1,8 @@
+<RadzenCard>
+    <p>Report for @Month.ToString("Y")</p>
+</RadzenCard>
+
+@code {
+    [Parameter]
+    public DateTime Month { get; set; }
+}

--- a/Components/SummaryCard.razor
+++ b/Components/SummaryCard.razor
@@ -1,0 +1,12 @@
+<RadzenCard Style="text-align:center;">
+    <h4>@Title</h4>
+    <p>@Value</p>
+</RadzenCard>
+
+@code {
+    [Parameter]
+    public string Title { get; set; } = string.Empty;
+
+    [Parameter]
+    public string Value { get; set; } = string.Empty;
+}

--- a/Components/TransactionList.razor
+++ b/Components/TransactionList.razor
@@ -1,0 +1,15 @@
+<RadzenDataGrid Data="Transactions" TItem="Transaction" RowSelect="OnSelect" Style="height:400px">
+    <Columns>
+        <RadzenDataGridColumn TItem="Transaction" Property="Date" Title="Date" />
+        <RadzenDataGridColumn TItem="Transaction" Property="Description" Title="Description" />
+        <RadzenDataGridColumn TItem="Transaction" Property="Amount" Title="Amount" />
+    </Columns>
+</RadzenDataGrid>
+
+@code {
+    [Parameter]
+    public IReadOnlyList<Transaction> Transactions { get; set; } = new List<Transaction>();
+
+    [Parameter]
+    public EventCallback<Transaction> OnSelect { get; set; }
+}

--- a/DoughTracker.csproj
+++ b/DoughTracker.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Radzen.Blazor" Version="4.16.0" />
+  </ItemGroup>
+</Project>

--- a/Models/Account.cs
+++ b/Models/Account.cs
@@ -1,0 +1,8 @@
+namespace DoughTracker.Models;
+
+public class Account
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+}

--- a/Models/Budget.cs
+++ b/Models/Budget.cs
@@ -1,0 +1,10 @@
+namespace DoughTracker.Models;
+
+public class Budget
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal TotalAmount { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+}

--- a/Models/BudgetItem.cs
+++ b/Models/BudgetItem.cs
@@ -1,0 +1,9 @@
+namespace DoughTracker.Models;
+
+public class BudgetItem
+{
+    public int Id { get; set; }
+    public int BudgetId { get; set; }
+    public int CategoryId { get; set; }
+    public decimal Amount { get; set; }
+}

--- a/Models/Category.cs
+++ b/Models/Category.cs
@@ -1,0 +1,14 @@
+namespace DoughTracker.Models;
+
+public enum CategoryType
+{
+    Expense,
+    Income
+}
+
+public class Category
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public CategoryType Type { get; set; }
+}

--- a/Models/Transaction.cs
+++ b/Models/Transaction.cs
@@ -1,0 +1,11 @@
+namespace DoughTracker.Models;
+
+public class Transaction
+{
+    public int Id { get; set; }
+    public DateTime Date { get; set; }
+    public decimal Amount { get; set; }
+    public int AccountId { get; set; }
+    public int CategoryId { get; set; }
+    public string Description { get; set; } = string.Empty;
+}

--- a/Pages/Categories.razor
+++ b/Pages/Categories.razor
@@ -1,0 +1,21 @@
+@page "/categories"
+
+<h3>Categories</h3>
+
+<RadzenButton Text="Add Category" ButtonStyle="ButtonStyle.Primary" Style="margin-bottom:10px" />
+
+<RadzenDataGrid Data="categories" TItem="Category" RowSelect="OnSelect">
+    <Columns>
+        <RadzenDataGridColumn TItem="Category" Property="Name" Title="Name" />
+        <RadzenDataGridColumn TItem="Category" Property="Type" Title="Type" />
+    </Columns>
+</RadzenDataGrid>
+
+@code {
+    private List<Category> categories = new();
+
+    private void OnSelect(Category category)
+    {
+        // Placeholder selection logic
+    }
+}

--- a/Pages/Dashboard.razor
+++ b/Pages/Dashboard.razor
@@ -1,0 +1,19 @@
+@page "/dashboard"
+
+<h3>Dashboard</h3>
+
+<RadzenRow>
+    <RadzenColumn Width="200px">
+        <SummaryCard Title="Accounts" Value="0" />
+    </RadzenColumn>
+    <RadzenColumn Width="200px">
+        <SummaryCard Title="Budgets" Value="0" />
+    </RadzenColumn>
+    <RadzenColumn Width="200px">
+        <SummaryCard Title="Transactions" Value="0" />
+    </RadzenColumn>
+</RadzenRow>
+
+<RadzenCard Style="margin-top:20px">
+    <p>Summary of your financial status.</p>
+</RadzenCard>

--- a/Pages/Error.cshtml
+++ b/Pages/Error.cshtml
@@ -1,0 +1,13 @@
+@page "Error"
+@{ Layout = null; }
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Error - DoughTracker</title>
+</head>
+<body>
+    <h1 class="text-danger">Error</h1>
+    <p>An error occurred while processing your request.</p>
+</body>
+</html>

--- a/Pages/FinancialOverview.razor
+++ b/Pages/FinancialOverview.razor
@@ -1,0 +1,17 @@
+@page "/overview"
+
+<h3>Financial Overview</h3>
+
+<RadzenRow>
+    <RadzenColumn Width="200px">
+        <SummaryCard Title="Total Balance" Value="$0" />
+    </RadzenColumn>
+    <RadzenColumn Width="200px">
+        <SummaryCard Title="Monthly Spending" Value="$0" />
+    </RadzenColumn>
+</RadzenRow>
+
+<RadzenCard Style="margin-top:20px">
+    <p>This page will display a summary of your finances after signing in.</p>
+</RadzenCard>
+

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -1,0 +1,4 @@
+@page "/"
+
+<h1>Welcome</h1>
+<p>This is the starting page for DoughTracker.</p>

--- a/Pages/Reports.razor
+++ b/Pages/Reports.razor
@@ -1,0 +1,9 @@
+@page "/reports"
+
+<h3>Reports</h3>
+
+<ExpenseChart />
+
+<RadzenCard Style="margin-top:20px">
+    <MonthlyReport Month="DateTime.Now" />
+</RadzenCard>

--- a/Pages/Settings.razor
+++ b/Pages/Settings.razor
@@ -1,0 +1,12 @@
+@page "/settings"
+
+<h3>Settings</h3>
+
+<RadzenPanelMenu Style="width:250px">
+    <RadzenPanelMenuItem Text="Profile" />
+    <RadzenPanelMenuItem Text="Data" />
+</RadzenPanelMenu>
+
+<RadzenCard Style="margin-top:20px">
+    <p>Adjust your preferences and data.</p>
+</RadzenCard>

--- a/Pages/SignIn.razor
+++ b/Pages/SignIn.razor
@@ -1,0 +1,39 @@
+@page "/signin"
+
+<h3>Sign In</h3>
+
+<RadzenTemplateForm Data="credentials" Submit="OnSignIn">
+    <RadzenFieldset Text="Credentials">
+        <RadzenLabel Text="Username or Email" Component="username" />
+        <RadzenTextBox @bind-Value="credentials.User" Name="username" Style="width:100%" />
+
+        <RadzenLabel Text="Password" Component="password" />
+        <RadzenPassword @bind-Value="credentials.Password" Name="password" Style="width:100%" />
+
+        <RadzenButton Text="Sign In" ButtonStyle="ButtonStyle.Primary" Type="Submit" Style="margin-top:10px" />
+    </RadzenFieldset>
+</RadzenTemplateForm>
+
+<div class="mt-2">
+    <a href="/forgot">Forgot password?</a>
+    |
+    <a href="/register">Create account</a>
+</div>
+
+@code {
+    private void OnSignIn()
+    {
+        NavigationManager.NavigateTo("/overview");
+    }
+
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+
+    private Credentials credentials = new();
+
+    private class Credentials
+    {
+        public string User { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/Pages/TransactionForm.razor
+++ b/Pages/TransactionForm.razor
@@ -1,0 +1,32 @@
+@page "/transaction"
+
+<h3>Transaction Form</h3>
+
+<RadzenTemplateForm Data="transaction" Submit="OnSave">
+    <RadzenFieldset Text="Details">
+        <RadzenLabel Text="Date" Component="date" />
+        <RadzenDatePicker @bind-Value="transaction.Date" Name="date" Style="width:100%" />
+
+        <RadzenLabel Text="Amount" Component="amount" />
+        <RadzenNumeric @bind-Value="transaction.Amount" Name="amount" Style="width:100%" />
+
+        <RadzenLabel Text="Category" Component="category" />
+        <CategoryDropdown Categories="categories" OnCategoryChanged="id => transaction.CategoryId = id" />
+
+        <RadzenButton Text="Save" ButtonStyle="ButtonStyle.Primary" Type="Submit" Style="margin-top:10px" />
+    </RadzenFieldset>
+</RadzenTemplateForm>
+
+@code {
+    private Transaction transaction = new();
+    private List<Category> categories = new();
+
+    private void OnSave()
+    {
+        // Save logic here
+        NavigationManager.NavigateTo("/transactions");
+    }
+
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+}

--- a/Pages/Transactions.razor
+++ b/Pages/Transactions.razor
@@ -1,0 +1,12 @@
+@page "/transactions"
+
+<h3>Transactions</h3>
+
+<RadzenButton Text="Add Transaction" ButtonStyle="ButtonStyle.Primary" Style="margin-bottom:10px" Click='() => NavigationManager.NavigateTo("/transaction")' />
+
+<TransactionList />
+
+@code {
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+}

--- a/Pages/_Host.cshtml
+++ b/Pages/_Host.cshtml
@@ -1,0 +1,25 @@
+@page "/"
+@namespace DoughTracker.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DoughTracker</title>
+    <base href="~/" />
+    <link rel="stylesheet" href="css/app.css" />
+    <link href="_content/Radzen.Blazor/css/default-base.css" rel="stylesheet" />
+    <link href="_content/Radzen.Blazor/css/default.css" rel="stylesheet" />
+</head>
+<body>
+    <app>
+        @(await Html.RenderComponentAsync<App>(RenderMode.Server))
+    </app>
+    <script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@namespace DoughTracker.Pages

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Radzen;
+
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+builder.Services.AddRazorPages();
+builder.Services.AddScoped<DialogService>();
+builder.Services.AddScoped<TooltipService>();
+builder.Services.AddScoped<NotificationService>();
+builder.Services.AddScoped<ContextMenuService>();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.MapRazorPages();
+
+app.MapFallbackToPage("/_Host");
+
+app.Run();
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,36 @@
 # DoughTracker
 
-This project is currently empty.
+This repository contains a skeleton Blazor Server project. The full project template could not be generated automatically because the `dotnet` SDK is not installed in this environment. Basic source files have been created manually so the project can be completed later with the .NET CLI.
 
+The starter project has been trimmed down to remove the default example pages. A few useful pages remain including `Index.razor`, `_ViewImports.cshtml`, and an `Error` page so the application still runs. In addition, a simple set of domain models is included to begin modeling the finance tracking functionality:
+
+* `Account` – represents a financial account and current balance
+* `Transaction` – records deposits or expenses for an account
+* `Category` – groups transactions as income or expense
+* `Budget` – tracks planned spending over a period
+* `BudgetItem` – assigns amounts to specific categories within a budget
+
+Additional starter pages include a Sign In form (`Pages/SignIn.razor`) and a placeholder Financial Overview page (`Pages/FinancialOverview.razor`). These demonstrate basic navigation that can later be hooked up to real authentication and finance data.
+
+## Available Pages
+
+The project now contains empty pages that will be fleshed out later:
+
+- `Pages/Dashboard.razor` – landing page showing a summary of totals and recent transactions
+- `Pages/Transactions.razor` – table of all transactions with filtering options
+- `Pages/TransactionForm.razor` – add or edit a single transaction
+- `Pages/Reports.razor` – monthly and category reports
+- `Pages/Categories.razor` – manage transaction categories
+- `Pages/Settings.razor` – user preferences
+
+Reusable components live under `Components/` and have been rebuilt using the [Radzen](https://blazor.radzen.com/) component library:
+
+- `TransactionList.razor`
+- `SummaryCard.razor`
+- `MonthlyReport.razor`
+- `ExpenseChart.razor`
+- `ConfirmDialog.razor`
+- `CategoryDropdown.razor`
+- `DateRangePicker.razor`
+
+The `_Host.cshtml` file includes the Radzen CSS and JavaScript references so the library works when running the app. The project file references the `Radzen.Blazor` package, but the package can't be restored until the .NET SDK is installed.

--- a/Shared/MainLayout.razor
+++ b/Shared/MainLayout.razor
@@ -1,0 +1,13 @@
+@inherits LayoutComponentBase
+
+<div class="page">
+    <div class="sidebar">
+        <NavMenu />
+    </div>
+
+    <main>
+        <article class="content px-4">
+            @Body
+        </article>
+    </main>
+</div>

--- a/Shared/NavMenu.razor
+++ b/Shared/NavMenu.razor
@@ -1,0 +1,25 @@
+<nav>
+    <ul class="nav flex-column">
+        <li class="nav-item px-3">
+            <NavLink href="/signin" class="nav-link" Match="NavLinkMatch.All">Sign In</NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink href="/overview" class="nav-link">Financial Overview</NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink href="/dashboard" class="nav-link">Dashboard</NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink href="/transactions" class="nav-link">Transactions</NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink href="/reports" class="nav-link">Reports</NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink href="/categories" class="nav-link">Categories</NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink href="/settings" class="nav-link">Settings</NavLink>
+        </li>
+    </ul>
+</nav>

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -1,0 +1,13 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using DoughTracker
+@using DoughTracker.Shared
+@using DoughTracker.Components
+@using Radzen
+@using Radzen.Blazor

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -1,0 +1,2 @@
+body { font-family: 'Segoe UI', Tahoma, Helvetica, Arial, sans-serif; margin:0; padding:0; }
+.nav-link { color: #007bff; }


### PR DESCRIPTION
## Summary
- expand nav menu with dashboard, transactions, reports and more
- create placeholder Razor pages for dashboard, transactions, reports and settings
- add a set of reusable components under `Components/`
- document the new pages and components in the README
- refactor pages and components to use Radzen

## Testing
- `dotnet build` *(fails: command not found)*【5adccf†L1-L4】
- `apt-get update` *(fails: repository access blocked)*【b318c1†L1-L14】

------
https://chatgpt.com/codex/tasks/task_e_6871cc48ed74832e840b6fd359743225