### PR TITLE
Implement cookie authentication for sign in

### DIFF
--- a/Pages/FinancialOverview.razor
+++ b/Pages/FinancialOverview.razor
@@ -1,4 +1,5 @@
 @page "/overview"
+@attribute [Authorize]
 
 <h3>Financial Overview</h3>
 

--- a/Pages/SignIn.razor
+++ b/Pages/SignIn.razor
@@ -1,4 +1,5 @@
 @page "/signin"
+@attribute [AllowAnonymous]
 
 <h3>Sign In</h3>
 
@@ -21,13 +22,20 @@
 </div>
 
 @code {
-    private void OnSignIn()
+    private async Task OnSignIn()
     {
-        NavigationManager.NavigateTo("/overview");
+        var result = await SignInManager.PasswordSignInAsync(credentials.User, credentials.Password, false, false);
+        if (result.Succeeded)
+        {
+            NavigationManager.NavigateTo("/overview");
+        }
     }
 
     [Inject]
     private NavigationManager NavigationManager { get; set; } = default!;
+
+    [Inject]
+    private SignInManager<IdentityUser> SignInManager { get; set; } = default!;
 
     private Credentials credentials = new();
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Identity;
+using DoughTracker.Services;
 using Radzen;
 
 
@@ -8,12 +10,41 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 builder.Services.AddRazorPages();
+builder.Services.AddSingleton<IUserStore<IdentityUser>, InMemoryUserStore>();
+builder.Services.AddIdentityCore<IdentityUser>(options =>
+{
+    options.Password.RequireNonAlphanumeric = false;
+})
+    .AddSignInManager()
+    .AddDefaultTokenProviders();
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultScheme = IdentityConstants.ApplicationScheme;
+})
+    .AddCookie(IdentityConstants.ApplicationScheme, options =>
+    {
+        options.Cookie.Name = "MyFinanceTracker.Auth";
+        options.LoginPath = "/signin";
+        options.LogoutPath = "/signout";
+        options.AccessDeniedPath = "/denied";
+    });
+builder.Services.AddAuthorization();
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<DialogService>();
 builder.Services.AddScoped<TooltipService>();
 builder.Services.AddScoped<NotificationService>();
 builder.Services.AddScoped<ContextMenuService>();
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var store = scope.ServiceProvider.GetRequiredService<IUserStore<IdentityUser>>();
+    var hasher = new PasswordHasher<IdentityUser>();
+    var user = new IdentityUser("admin") { NormalizedUserName = "ADMIN" };
+    user.PasswordHash = hasher.HashPassword(user, "password");
+    store.CreateAsync(user, CancellationToken.None).GetAwaiter().GetResult();
+}
 
 if (!app.Environment.IsDevelopment())
 {
@@ -25,6 +56,8 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/Services/InMemoryUserStore.cs
+++ b/Services/InMemoryUserStore.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Identity;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace DoughTracker.Services;
+
+public class InMemoryUserStore : IUserPasswordStore<IdentityUser>
+{
+    private readonly ConcurrentDictionary<string, IdentityUser> _users = new();
+
+    public Task<IdentityResult> CreateAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        _users[user.Id] = user;
+        return Task.FromResult(IdentityResult.Success);
+    }
+
+    public Task<IdentityResult> DeleteAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        _users.TryRemove(user.Id, out _);
+        return Task.FromResult(IdentityResult.Success);
+    }
+
+    public void Dispose() { }
+
+    public Task<IdentityUser?> FindByIdAsync(string userId, CancellationToken cancellationToken)
+    {
+        _users.TryGetValue(userId, out var user);
+        return Task.FromResult(user);
+    }
+
+    public Task<IdentityUser?> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)
+    {
+        var user = _users.Values.FirstOrDefault(u => u.NormalizedUserName == normalizedUserName);
+        return Task.FromResult(user);
+    }
+
+    public Task<string?> GetNormalizedUserNameAsync(IdentityUser user, CancellationToken cancellationToken)
+        => Task.FromResult(user.NormalizedUserName);
+
+    public Task<string> GetUserIdAsync(IdentityUser user, CancellationToken cancellationToken)
+        => Task.FromResult(user.Id);
+
+    public Task<string?> GetUserNameAsync(IdentityUser user, CancellationToken cancellationToken)
+        => Task.FromResult(user.UserName);
+
+    public Task SetNormalizedUserNameAsync(IdentityUser user, string normalizedName, CancellationToken cancellationToken)
+    {
+        user.NormalizedUserName = normalizedName;
+        return Task.CompletedTask;
+    }
+
+    public Task SetUserNameAsync(IdentityUser user, string userName, CancellationToken cancellationToken)
+    {
+        user.UserName = userName;
+        return Task.CompletedTask;
+    }
+
+    public Task<IdentityResult> UpdateAsync(IdentityUser user, CancellationToken cancellationToken)
+    {
+        _users[user.Id] = user;
+        return Task.FromResult(IdentityResult.Success);
+    }
+
+    public Task SetPasswordHashAsync(IdentityUser user, string passwordHash, CancellationToken cancellationToken)
+    {
+        user.PasswordHash = passwordHash;
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> GetPasswordHashAsync(IdentityUser user, CancellationToken cancellationToken)
+        => Task.FromResult(user.PasswordHash);
+
+    public Task<bool> HasPasswordAsync(IdentityUser user, CancellationToken cancellationToken)
+        => Task.FromResult(user.PasswordHash != null);
+
+    public void SeedUser(IdentityUser user)
+    {
+        _users[user.Id] = user;
+    }
+}

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -11,3 +11,7 @@
 @using DoughTracker.Components
 @using Radzen
 @using Radzen.Blazor
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Authentication
+@using Microsoft.AspNetCore.Authentication.Cookies
+@using Microsoft.AspNetCore.Identity


### PR DESCRIPTION
## Summary
- enable ASP.NET Core Identity with an in-memory user store
- seed a default user and configure Identity cookie auth
- use `SignInManager` on the sign-in page
- mark overview page as authorized
- expose Identity namespace globally
- configure Identity cookie options
- fix duplicate registration of the auth cookie

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871e096e65c832e857394006c443d2f